### PR TITLE
Add scrolling announcements marquee to navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "i18next-browser-languagedetector": "^8.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-fast-marquee": "^1.6.5",
         "react-i18next": "^15.6.0",
         "react-markdown": "^10.1.0",
         "react-player": "^3.3.1",
@@ -3241,6 +3242,16 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-fast-marquee": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/react-fast-marquee/-/react-fast-marquee-1.6.5.tgz",
+      "integrity": "sha512-swDnPqrT2XISAih0o74zQVE2wQJFMvkx+9VZXYYNSLb/CUcAzU9pNj637Ar2+hyRw6b4tP6xh4GQZip2ZCpQpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.8.0 || ^18.0.0",
+        "react-dom": ">= 16.8.0 || ^18.0.0"
       }
     },
     "node_modules/react-i18next": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,12 @@
   "name": "logic-in-philosophy",
   "version": "1.0.0",
   "type": "module",
-  
   "scripts": {
-  "dev": "vite",
-  "build": "vite build",
-  "preview": "vite preview",
-  "deploy": "vite build"
-}
-,
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "deploy": "vite build"
+  },
   "dependencies": {
     "@vitejs/plugin-react": "^4.6.0",
     "framer-motion": "^12.23.6",
@@ -17,6 +15,7 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-fast-marquee": "^1.6.5",
     "react-i18next": "^15.6.0",
     "react-markdown": "^10.1.0",
     "react-player": "^3.3.1",

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,17 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import LanguageSwitcher from "./LanguageSwitcher"; 
+import LanguageSwitcher from "./LanguageSwitcher";
 import { useTranslation } from "react-i18next";
+import Marquee from "react-fast-marquee";
 
 export default function Navbar() {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
+  const announcements = [
+    "Call for Papers: Logic in AI",
+    "Video: 2024 Workshop recordings live",
+    "New! Hebrew translations of resources",
+  ];
 
   return (
     <header className="bg-black text-white">
@@ -51,6 +57,13 @@ export default function Navbar() {
         </ul>
         <LanguageSwitcher />
       </nav>
+      <Marquee speed={40} className="bg-bauBlue text-white">
+        {announcements.map((item, idx) => (
+          <span key={idx} className="mx-4">
+            {item}
+          </span>
+        ))}
+      </Marquee>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add react-fast-marquee dependency
- show announcements in scrolling marquee below main nav

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890977af2bc8328a9cc292c1d8e1939