### PR TITLE
refactor: enhance sticky navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,29 +1,49 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useTranslation } from "react-i18next";
 import Marquee from "react-fast-marquee";
 
-export default function Navbar() {
-  const [open, setOpen] = useState(false);
+function Navbar() {
   const { t } = useTranslation();
-   const announcements = [
+  const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const links = [
+    { to: "/about", label: t("nav.about") },
+    { to: "/workshop", label: "Workshop" },
+    { to: "/media", label: "Media" },
+    { to: "/resources", label: "Resources" },
+    { to: "/archive", label: "Archive" },
+    { to: "/contact", label: "Contact" },
+  ];
+
+  const announcements = [
     "Call for Papers: Logic in AI",
     "Video: 2024 Workshop recordings live",
     "New! Hebrew translations of resources",
   ];
 
   return (
-    <header className="bg-black text-white">
-      <nav className="container mx-auto flex flex-wrap items-center justify-between p-4">
+    <header
+      className={`sticky top-0 w-full z-50 text-white transition-colors ${
+        scrolled ? "bg-black/80" : "bg-transparent"
+      }`}
+    >
+      <nav className="container mx-auto flex items-center justify-between p-4">
         <Link to="/" className="text-xl font-semibold">
           Logic in Philosophy
         </Link>
 
-        {/* mobile toggle */}
         <button
           className="ml-auto block md:hidden"
-          onClick={() => setOpen(!open)}
+          onClick={() => setOpen(true)}
           aria-label="Toggle navigation"
         >
           <svg
@@ -41,29 +61,69 @@ export default function Navbar() {
           </svg>
         </button>
 
-        {/* links */}
-        <ul
-          className={`w-full md:flex md:items-center md:space-x-4 md:w-auto ${
-            open ? "block" : "hidden"
-          }`}
-        >
-          <li><Link to="/about" className="block py-1 px-2 hover:underline">About</Link></li>
-          <li><Link to="/workshop" className="block py-1 px-2 hover:underline">Workshop</Link></li>
-          <li><Link to="/media" className="block py-1 px-2 hover:underline">Media</Link></li>
-          <li><Link to="/resources" className="block py-1 px-2 hover:underline">Resources</Link></li>
-          <li><Link to="/archive" className="block py-1 px-2 hover:underline">Archive</Link></li>
-          <li><Link to="/contact" className="block py-1 px-2 hover:underline">Contact</Link></li>
-          <li><Link to="/about">{t("nav.about")}</Link></li>
+        <ul className="hidden md:flex md:items-center">
+          {links.map((link) => (
+            <li key={link.to}>
+              <Link
+                to={link.to}
+                className="nav-underline ml-6 md:ml-0"
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
         </ul>
         <LanguageSwitcher />
       </nav>
-            <Marquee speed={40} className="bg-bauBlue text-white">
+
+      <Marquee speed={40} className="bg-bauBlue text-white">
         {announcements.map((item, idx) => (
           <span key={idx} className="mx-4">
             {item}
           </span>
         ))}
       </Marquee>
+
+      <div
+        className={`fixed inset-y-0 right-0 w-64 bg-black/80 p-6 transition-transform duration-300 transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        } md:hidden`}
+      >
+        <button
+          className="mb-4 ml-auto block"
+          onClick={() => setOpen(false)}
+          aria-label="Close navigation"
+        >
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        <ul>
+          {links.map((link) => (
+            <li key={link.to} className="py-2">
+              <Link
+                to={link.to}
+                className="nav-underline ml-6 md:ml-0"
+                onClick={() => setOpen(false)}
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
     </header>
   );
 }
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- make Navbar sticky with translucent black background on scroll
- add slide-in mobile menu and nav-underline styling for links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689456f999488328bd268525a2c0eae5